### PR TITLE
Pass in a mongo connection string rather than trying to build it

### DIFF
--- a/src/MigrationJob.js
+++ b/src/MigrationJob.js
@@ -13,7 +13,7 @@ class MigrationJob {
         this.mapperFunction = (item) => { return item; };
         this.filterFunction = () => { return true; };
         this.dynamoDBDAO = new DynamoDBDAO(sourceTableName,sourceConnectionOptions.region,sourceConnectionOptions.accessKeyId,sourceConnectionOptions.secretAccessKey);
-        this.mongoDBDAO = new MongoDBDAO(this.targetTableName, this.targetDbName,targetConnectionOptions.host, targetConnectionOptions.user, targetConnectionOptions.password);
+        this.mongoDBDAO = new MongoDBDAO(this.targetTableName, this.targetDbName, targetConnectionOptions.connectionString);
         this.dynamodbEvalLimit = dynamodbEvalLimit || 100;
         this.filterExpression = null;
         this.expressionAttributeNames = null;

--- a/src/connectors/MongoDBConnector.js
+++ b/src/connectors/MongoDBConnector.js
@@ -9,16 +9,15 @@ let client;
 
 class MongoDBConnector {
 
-    static getConnection(database,host,user,password) {
+    static getConnection(databaseName, connectionString) {
         return new Promise(async (resolve, reject) => {
             try {
                 if (client) {
-                    resolve(client.db(database));
+                    resolve(client.db(databaseName));
                 } else {
-                    let url = 'mongodb://' + user + ':' + password + '@' + host;
-                    client = new MongoClient(url,{ useNewUrlParser: true });
+                    client = new MongoClient(connectionString);
                     await client.connect();
-                    resolve(client.db(database));
+                    resolve(client.db(databaseName));
                 }
             } catch (error) {
                 console.error(error);

--- a/src/dao/MongoDBDAO.js
+++ b/src/dao/MongoDBDAO.js
@@ -3,16 +3,14 @@ const lodash = require('lodash');
 const MongoDBConnector = require('./../connectors/MongoDBConnector');
 
 class MongoDBDAO {
-    constructor(tableName, databaseName,host,user,password) {
+    constructor(tableName, databaseName, connectionString) {
         this.tableName = tableName;
-        this.databaseName = databaseName;
-        this.host = host;
-        this.user = user;
-        this.password = password;
-    }
+        this.databaseName = databaseName
+        this.connectionString = connectionString;
+      }
 
     async intertOrUpdateItems(items) {
-        let dbConn = await MongoDBConnector.getConnection(this.databaseName,this.host,this.user,this.password);
+        let dbConn = await MongoDBConnector.getConnection(this.databaseName, this.connectionString);
         let collection = dbConn.collection(this.tableName);
         let bulkWriteReqArray = lodash.map(items, (item) => {
             return {


### PR DESCRIPTION
Keep the connection generic so users can transparently pass it in.